### PR TITLE
bump faer version to 0.19.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ path = 'src/lib.rs'
 [dependencies]
 assert_approx_eq = "1.1.0"
 num-traits = "0.2.18"
-faer = {version = "0.18.2"}
+faer = {version = "0.19.0"}


### PR DESCRIPTION
- bump version of faer dep to 0.19.0
- adds gitignore